### PR TITLE
"Fix" stuttering when turning the player about the Y axis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
 
 tasks.processResources {
+    outputs.upToDateWhen { false }
     filesMatching("fabric.mod.json") {
         expand("version" to project.version)
     }

--- a/src/main/java/me/lucyydotp/papers/CameraPerspectiveMode.java
+++ b/src/main/java/me/lucyydotp/papers/CameraPerspectiveMode.java
@@ -34,9 +34,12 @@ public sealed interface CameraPerspectiveMode {
         private final ArmorStand armorStand;
         private final long creationTime;
 
+        private float lastHeadY;
+
         public ArmorStandHead(ArmorStand armorStand) {
             this.armorStand = armorStand;
             this.creationTime = armorStand.level.getGameTime();
+            this.lastHeadY = armorStand.yHeadRot;
         }
 
         /**
@@ -56,7 +59,11 @@ public sealed interface CameraPerspectiveMode {
             final var player = Minecraft.getInstance().player;
             if (!player.isPassenger()) return;
 
-            player.setYRot(Mth.rotLerp(tickProgress, armorStand.yRotO, armorStand.getYRot()));
+//            player.setYRot(player.getYRot() + tickProgress * -Mth.degreesDifference(armorStand.getYRot(), armorStand.yRotO));
+
+            final var lerp = Mth.rotLerp(tickProgress, armorStand.yRotO, armorStand.getYRot());
+            player.setYRot(player.getYRot() + lerp - lastHeadY);
+            lastHeadY = lerp;
 
             final var pose = armorStand.getHeadPose();
             final var lastPose = ((ArmorStandExt) armorStand).paper$lastHeadRot();

--- a/src/main/java/me/lucyydotp/papers/CameraPerspectiveMode.java
+++ b/src/main/java/me/lucyydotp/papers/CameraPerspectiveMode.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Quaternionf;
-import org.joml.Vector3f;
 
 /**
  * A camera perspective mode.
@@ -34,12 +33,12 @@ public sealed interface CameraPerspectiveMode {
         private final ArmorStand armorStand;
         private final long creationTime;
 
-        private float lastHeadY;
+        private float lastYRot;
 
         public ArmorStandHead(ArmorStand armorStand) {
             this.armorStand = armorStand;
             this.creationTime = armorStand.level.getGameTime();
-            this.lastHeadY = armorStand.yHeadRot;
+            this.lastYRot = armorStand.yHeadRot;
         }
 
         /**
@@ -59,15 +58,13 @@ public sealed interface CameraPerspectiveMode {
             final var player = Minecraft.getInstance().player;
             if (!player.isPassenger()) return;
 
-//            player.setYRot(player.getYRot() + tickProgress * -Mth.degreesDifference(armorStand.getYRot(), armorStand.yRotO));
-
-            final var lerp = Mth.rotLerp(tickProgress, armorStand.yRotO, armorStand.getYRot());
-            player.setYRot(player.getYRot() + lerp - lastHeadY);
-            lastHeadY = lerp;
+            final var lerpedYRot = Mth.rotLerp(tickProgress, armorStand.yRotO, armorStand.getYRot());
+            player.setYRot(player.getYRot() + lerpedYRot - lastYRot);
+            lastYRot = lerpedYRot;
 
             final var pose = armorStand.getHeadPose();
             final var lastPose = ((ArmorStandExt) armorStand).paper$lastHeadRot();
-            final var forward = Vec3.directionFromRotation(0, lerp).toVector3f();
+            final var forward = Vec3.directionFromRotation(0, lerpedYRot).toVector3f();
 
             // fixme: properly slerp instead of doing whatever this is
             cameraPoseStack.rotateAround(

--- a/src/main/java/me/lucyydotp/papers/CameraPerspectiveMode.java
+++ b/src/main/java/me/lucyydotp/papers/CameraPerspectiveMode.java
@@ -67,12 +67,13 @@ public sealed interface CameraPerspectiveMode {
 
             final var pose = armorStand.getHeadPose();
             final var lastPose = ((ArmorStandExt) armorStand).paper$lastHeadRot();
-            final var forward = Vec3.directionFromRotation(0, player.getYRot()).toVector3f();
+            final var forward = Vec3.directionFromRotation(0, lerp).toVector3f();
 
+            // fixme: properly slerp instead of doing whatever this is
             cameraPoseStack.rotateAround(
                     new Quaternionf()
                             .rotateAxis((float) Math.toRadians(Mth.rotLerp(tickProgress, lastPose.getZ(), pose.getZ())), forward)
-                            .rotateAxis((float) Math.toRadians(Mth.rotLerp(tickProgress, lastPose.getY(), pose.getY())), player.getUpVector(1).toVector3f())
+                            .rotateLocalY((float) Math.toRadians(Mth.rotLerp(tickProgress, lastPose.getY(), pose.getY())))
                             .rotateAxis((float) Math.toRadians(Mth.rotLerp(tickProgress, lastPose.getX(), pose.getX())), forward.rotateY((float) (Math.PI / -2f))),
                     0,
                     // fixme: i completely made this value up. it feels okay-ish but isn't right

--- a/src/main/java/me/lucyydotp/papers/mixin/GameRendererMixin.java
+++ b/src/main/java/me/lucyydotp/papers/mixin/GameRendererMixin.java
@@ -7,7 +7,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
@@ -31,19 +30,17 @@ public class GameRendererMixin {
     /**
      * Applies the active perspective mode's camera transformation.
      */
-    @ModifyArg(
+    @Inject(
             method = "renderLevel",
             at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/LevelRenderer;prepareCullFrustum(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/phys/Vec3;Lorg/joml/Matrix4f;)V",
-                    ordinal = 0
+                    value = "NEW",
+                    target = "org/joml/Matrix3f"
             )
     )
-    public PoseStack addRidePerspectiveRotation(PoseStack poseStack) {
+    public void addRidePerspectiveRotation(float f, long l, PoseStack poseStack, CallbackInfo ci) {
         final var perspectiveMode = PassengerPerspectiveMod.getPerspectiveMode();
         if (perspectiveMode != null) {
             perspectiveMode.transform(poseStack, papers$f, papers$l);
         }
-        return poseStack;
     }
 }

--- a/src/main/java/me/lucyydotp/papers/mixin/GameRendererMixin.java
+++ b/src/main/java/me/lucyydotp/papers/mixin/GameRendererMixin.java
@@ -4,29 +4,12 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import me.lucyydotp.papers.PassengerPerspectiveMod;
 import net.minecraft.client.renderer.GameRenderer;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
 public class GameRendererMixin {
-
-    @Unique
-    private float papers$f;
-
-    @Unique
-    private long papers$l;
-
-    @Inject(
-            method = "renderLevel",
-            at = @At("HEAD")
-    )
-    public void setF(float f, long l, PoseStack poseStack, CallbackInfo ci) {
-        papers$f = f;
-        papers$l = l;
-    }
-
     /**
      * Applies the active perspective mode's camera transformation.
      */
@@ -40,7 +23,7 @@ public class GameRendererMixin {
     public void addRidePerspectiveRotation(float f, long l, PoseStack poseStack, CallbackInfo ci) {
         final var perspectiveMode = PassengerPerspectiveMod.getPerspectiveMode();
         if (perspectiveMode != null) {
-            perspectiveMode.transform(poseStack, papers$f, papers$l);
+            perspectiveMode.transform(poseStack, f, l);
         }
     }
 }


### PR DESCRIPTION
By "fix" i mean throw more misguided rotlerping at the problem so that it's not noticeable. It still moves weirdly, but now it does it smoothly so it's less jarring.
Also correct the forward axis used for X and Z rotation